### PR TITLE
Fixed the error while creating symlink

### DIFF
--- a/run-natively.sh
+++ b/run-natively.sh
@@ -45,7 +45,7 @@ if echo "$answer" | grep -iq "^y" ;then
     grunt build #CMD
 
     cd ${BASEDIR}/shim-server/src/main/resources #CMD
-    ln -sfh ../../../../shim-server-ui/docker/assets public
+    ln -sf ../../../../shim-server-ui/docker/assets public
     #CMD create a symlink called shim-server/src/main/resources/public to the Grunt output directory
 fi
 


### PR DESCRIPTION
run-natively.sh ends up in an error while trying to create a symbolic link. Removed the '-h' option for 'ln' and it worked on my machine. I couldn't find the option '-h' in the man pages as well for 'ln' command. Kindly take a look at the pull request created.