### PR TITLE
Modified Withings Endpoints to Point to Nokia Endpoints

### DIFF
--- a/shim-server/src/main/java/org/openmhealth/shim/withings/WithingsShim.java
+++ b/shim-server/src/main/java/org/openmhealth/shim/withings/WithingsShim.java
@@ -61,7 +61,7 @@ public class WithingsShim extends OAuth1ShimBase {
 
     private static final String REQUEST_TOKEN_URL = "https://developer.health.nokia.com/account/request_token";
 
-    private static final String AUTHORIZE_URL = "https://developer.health.nokia.com/account/authorizee";
+    private static final String AUTHORIZE_URL = "https://developer.health.nokia.com/account/authorize";
 
     private static final String TOKEN_URL = "https://developer.health.nokia.com/account/access_token";
 

--- a/shim-server/src/main/java/org/openmhealth/shim/withings/WithingsShim.java
+++ b/shim-server/src/main/java/org/openmhealth/shim/withings/WithingsShim.java
@@ -57,13 +57,13 @@ public class WithingsShim extends OAuth1ShimBase {
 
     public static final String SHIM_KEY = "withings";
 
-    private static final String DATA_URL = "http://wbsapi.withings.net";
+    private static final String DATA_URL = "https://api.health.nokia.com";
 
-    private static final String REQUEST_TOKEN_URL = "https://oauth.withings.com/account/request_token";
+    private static final String REQUEST_TOKEN_URL = "https://developer.health.nokia.com/account/request_token";
 
-    private static final String AUTHORIZE_URL = "https://oauth.withings.com/account/authorize";
+    private static final String AUTHORIZE_URL = "https://developer.health.nokia.com/account/authorizee";
 
-    private static final String TOKEN_URL = "https://oauth.withings.com/account/access_token";
+    private static final String TOKEN_URL = "https://developer.health.nokia.com/account/access_token";
 
     private static final String PARTNER_ACCESS_ACTIVITY_ENDPOINT = "getintradayactivity";
 


### PR DESCRIPTION
As Withings has been taken over by Nokia and as part of the rebranding process following  withings endpoints has been modified by  Nokia. I have made the changes in the WithingsShim.java file to incorporate these changes. I was testing the application today with the Old URLs and I faced issues while getting the access tokens. However, after making the changes the application worked perfectly fine.

Details are as below:

DATA_URL = "http://wbsapi.withings.net" **has been changed to** "https://api.health.nokia.com"


REQUEST_TOKEN_URL = "https://oauth.withings.com/account/request_token" **has been changed to** "https://developer.health.nokia.com/account/request_token"

AUTHORIZE_URL = "https://oauth.withings.com/account/authorize" **has been changed to** "https://developer.health.nokia.com/account/authorize"


TOKEN_URL = "https://oauth.withings.com/account/access_token" **has been changed to** "https://developer.health.nokia.com/account/access_token"

Please let me know if the changes are legitimate to be incorporated.







