### PR TITLE
Fix postman normalize variable name

### DIFF
--- a/resources/postman/postman-collection.json
+++ b/resources/postman/postman-collection.json
@@ -862,7 +862,7 @@
 							"name": "Fitbit",
 							"originalRequest": {
 								"url": {
-									"raw": "{{api-base-url}}/data/{{shim-key}}/sleep_duration?username={{username}}&normalized={{normalized}}&dateStart={{start-date}}&dateEnd={{end-date}}",
+									"raw": "{{api-base-url}}/data/{{shim-key}}/sleep_duration?username={{username}}&normalize={{normalize}}&dateStart={{start-date}}&dateEnd={{end-date}}",
 									"host": [
 										"{{api-base-url}}"
 									],
@@ -879,8 +879,8 @@
 											"description": ""
 										},
 										{
-											"key": "normalized",
-											"value": "{{normalized}}",
+											"key": "normalize",
+											"value": "{{normalize}}",
 											"equals": true,
 											"description": ""
 										},

--- a/resources/postman/postman-environment.json
+++ b/resources/postman/postman-environment.json
@@ -34,7 +34,7 @@
     },
     {
       "enabled": true,
-      "key": "normalized",
+      "key": "normalize",
       "value": "true",
       "type": "text"
     }


### PR DESCRIPTION
There are two normalize references variants: normalize and normalized.
Based on the existing requests and the code, it seems to be a typo.