### PR TITLE
Updating the URL

### DIFF
--- a/shim-server/src/main/java/org/openmhealth/shim/runkeeper/RunKeeper.md
+++ b/shim-server/src/main/java/org/openmhealth/shim/runkeeper/RunKeeper.md
@@ -1,7 +1,7 @@
 ### still a scratch pad for now...
 
 # general
-docs main page: https://http://developer.runkeeper.com/healthgraph/overview/
+docs main page: https://runkeeper.com/developer/healthgraph/ (sign-in first)
 
 # getting started on RunKeeper
 


### PR DESCRIPTION
The original RunKeeper URL incorrectly included both http:// and https:// -- this makes that link correct.